### PR TITLE
🚑 Fix the max() on empty sequence error

### DIFF
--- a/forecast_solar/models.py
+++ b/forecast_solar/models.py
@@ -51,7 +51,7 @@ class Estimate:
     def power_highest_peak_time_today(self) -> datetime:
         """Return datetime with highest power production moment today."""
         now = datetime.now(tz=timezone.utc).replace(minute=59, second=59)
-        value = max(watt for date, watt in self.watts.items() if date.day == now.day)
+        value = max((watt for date, watt in self.watts.items() if date.day == now.day), default=0)
         for (
             date,
             watt,
@@ -65,7 +65,7 @@ class Estimate:
         nxt = datetime.now(tz=timezone.utc).replace(minute=59, second=59) + timedelta(
             hours=24
         )
-        value = max(watt for date, watt in self.watts.items() if date.day == nxt.day)
+        value = max((watt for date, watt in self.watts.items() if date.day == nxt.day), default=0)
         for (
             date,
             watt,

--- a/forecast_solar/models.py
+++ b/forecast_solar/models.py
@@ -51,7 +51,10 @@ class Estimate:
     def power_highest_peak_time_today(self) -> datetime:
         """Return datetime with highest power production moment today."""
         now = datetime.now(tz=timezone.utc).replace(minute=59, second=59)
-        value = max((watt for date, watt in self.watts.items() if date.day == now.day), default=0)
+        value = max(
+            (watt for date, watt in self.watts.items() if date.day == now.day),
+            default=None,
+        )
         for (
             date,
             watt,
@@ -65,7 +68,10 @@ class Estimate:
         nxt = datetime.now(tz=timezone.utc).replace(minute=59, second=59) + timedelta(
             hours=24
         )
-        value = max((watt for date, watt in self.watts.items() if date.day == nxt.day), default=0)
+        value = max(
+            (watt for date, watt in self.watts.items() if date.day == nxt.day),
+            default=None,
+        )
         for (
             date,
             watt,


### PR DESCRIPTION
This will fix the error: `max() arg is an empty sequence`.
This occurs when there are no more values due to the transition to the next day.

Linked issue: https://github.com/home-assistant/core/issues/52896

Must test this before merging!