### PR TITLE
Fix finding peak

### DIFF
--- a/forecast_solar/models.py
+++ b/forecast_solar/models.py
@@ -58,7 +58,7 @@ class Estimate:
         """Return datetime with highest power production moment today."""
         now = datetime.now(tz=zoneinfo.ZoneInfo(self.api_timezone)).replace(
             minute=59, second=59
-        ) + timedelta(hours=24)
+        )
         value = max(
             (watt for date, watt in self.watts.items() if date.day == now.day),
             default=None,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,11 @@ setup(
     ],
     description="Asynchronous Python client for getting forecast solar information",
     include_package_data=True,
-    install_requires=["aiohttp>=3.0.0", "aiodns>=3.0.0"],
+    install_requires=[
+        "aiohttp>=3.0.0",
+        "aiodns>=3.0.0",
+        'backports.zoneinfo;python_version<"3.9"',
+    ],
     keywords=["forecast", "solar", "power", "energy", "api", "async", "client"],
     license="MIT license",
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/52763

The Estimate model was converting all incoming timestamps to UTC. This caused us to lose the ability to easily check what is today vs tomorrow.

Generally for API design, we should avoid mutating data and just represent the data as-is from the source. It's up to the consumer of the lib to process it. 

In Python we have datetime objects that are timezone aware and timezone unaware.

Timezone aware objects work with timezone aware objects. Unaware objects only work with unaware. 

So it's fine to have an aware object be in non-UTC. Just make sure in Home Assistant you convert it to UTC before you push it to the state machine.

## Breaking Change

All datetime values in the Estimate object are now in the original timezone instead of UTC.