### PR TITLE
Add exception raise for bad gateway

### DIFF
--- a/forecast_solar/__init__.py
+++ b/forecast_solar/__init__.py
@@ -101,6 +101,11 @@ class ForecastSolar:
             ssl=False,
         )
 
+        if response.status == 502:
+            raise ForecastSolarConnectionError(
+                "The Forecast.Solar API is unreachable, "
+            )
+
         if response.status < 500:
             self.ratelimit = Ratelimit.from_response(response)
 
@@ -111,11 +116,6 @@ class ForecastSolar:
         if response.status == 429:
             data = await response.json()
             raise ForecastSolarRatelimit(data["message"])
-
-        if response.status == 502:
-            raise ForecastSolarConnectionError(
-                "The Forecast.Solar API is unreachable, "
-            )
 
         response.raise_for_status()
 

--- a/forecast_solar/__init__.py
+++ b/forecast_solar/__init__.py
@@ -112,6 +112,11 @@ class ForecastSolar:
             data = await response.json()
             raise ForecastSolarRatelimit(data["message"])
 
+        if response.status == 502:
+            raise ForecastSolarConnectionError(
+                "The Forecast.Solar API is unreachable, "
+            )
+
         response.raise_for_status()
 
         content_type = response.headers.get("Content-Type", "")


### PR DESCRIPTION
Since the API is sometimes down, an extra exception raise for a 502 response.

Perhaps the text could be a little more powerful?