### PR TITLE
Fix exception for invalid api key

### DIFF
--- a/forecast_solar/__init__.py
+++ b/forecast_solar/__init__.py
@@ -109,7 +109,7 @@ class ForecastSolar:
         if response.status < 500:
             self.ratelimit = Ratelimit.from_response(response)
 
-        if response.status == 400:
+        if response.status in [400, 403]:
             data = await response.json()
             raise ForecastSolarRequestError(data["message"])
 

--- a/forecast_solar/__init__.py
+++ b/forecast_solar/__init__.py
@@ -108,7 +108,6 @@ class ForecastSolar:
                 "The Forecast.Solar API is unreachable, "
             )
 
-
         if response.status == 400:
             data = await response.json()
             raise ForecastSolarRequestError(data["message"])

--- a/forecast_solar/__init__.py
+++ b/forecast_solar/__init__.py
@@ -11,6 +11,7 @@ from aiohttp import ClientSession
 from yarl import URL
 
 from .exceptions import (
+    ForecastSolarAuthenticationError,
     ForecastSolarConnectionError,
     ForecastSolarError,
     ForecastSolarRequestError,
@@ -54,6 +55,7 @@ class ForecastSolar:
             the Forecast.Solar API.
 
         Raises:
+            ForecastSolarAuthenticationError: If the API key is invalid.
             ForecastSolarConnectionError: An error occurred while communicating
                 with the Forecast.Solar API.
             ForecastSolarError: Received an unexpected response from the
@@ -106,16 +108,21 @@ class ForecastSolar:
                 "The Forecast.Solar API is unreachable, "
             )
 
-        if response.status < 500:
-            self.ratelimit = Ratelimit.from_response(response)
 
-        if response.status in [400, 403]:
+        if response.status == 400:
             data = await response.json()
             raise ForecastSolarRequestError(data["message"])
+
+        if response.status == 403:
+            data = await response.json()
+            raise ForecastSolarAuthenticationError(data["message"])
 
         if response.status == 429:
             data = await response.json()
             raise ForecastSolarRatelimit(data["message"])
+
+        if response.status < 500:
+            self.ratelimit = Ratelimit.from_response(response)
 
         response.raise_for_status()
 

--- a/forecast_solar/exceptions.py
+++ b/forecast_solar/exceptions.py
@@ -21,6 +21,7 @@ class ForecastSolarAuthenticationError(ForecastSolarError):
         super().__init__(f'{data["text"]} (error {data["code"]})')
         self.code = data["code"]
 
+
 class ForecastSolarRequestError(ForecastSolarError):
     """Forecast.Solar wrong request input variables."""
 

--- a/forecast_solar/exceptions.py
+++ b/forecast_solar/exceptions.py
@@ -10,6 +10,17 @@ class ForecastSolarConnectionError(ForecastSolarError):
     """Forecast.Solar API connection exception."""
 
 
+class ForecastSolarAuthenticationError(ForecastSolarError):
+    """Forecast.Solar API authentication exception."""
+
+    def __init__(self, data: dict) -> None:
+        """Init a solar auth error.
+
+        https://doc.forecast.solar/doku.php?id=api#invalid_request
+        """
+        super().__init__(f'{data["text"]} (error {data["code"]})')
+        self.code = data["code"]
+
 class ForecastSolarRequestError(ForecastSolarError):
     """Forecast.Solar wrong request input variables."""
 


### PR DESCRIPTION
This will add status code 403 to RequestError exception, because error messages related to the api key do not fall under error 400 but 403.