### PR TITLE
Use api.forecast.solar host in API calls

### DIFF
--- a/forecast_solar/__init__.py
+++ b/forecast_solar/__init__.py
@@ -84,7 +84,7 @@ class ForecastSolar:
             )
 
         # Connect as normal
-        url = URL.build(scheme="https", host=result[0].host)
+        url = URL.build(scheme="https", host="api.forecast.solar")
 
         # Add API key if one is provided
         if self.api_key is not None:


### PR DESCRIPTION
Rather than using the looked-up IP address for API calls, use 'api.forecast.solar' so that certificate for https call matches.

For context, I'm getting the error:
`Config entry 'Preesall' for forecast_solar integration not ready yet: 0, message='Attempt to decode JSON with unexpected mimetype: text/html', url=URL('https://148.251.178.234/estimate/53.xxx/-2.xxx/36/30/4.0?time=iso8601&damping=0.0&inverter=4.0'); Retrying in background`

This is due to my firewall seeing that the certificate presented by the API server at 148.251.178.234 is for pv-log.net and has expired. Sending the correct host header ("api.forecast.solar") gets the correct certificate and will not fall foul of any certificate inspection firewalls.