### PR TITLE
Add config error exception to handle 422 status code

### DIFF
--- a/forecast_solar/__init__.py
+++ b/forecast_solar/__init__.py
@@ -12,10 +12,11 @@ from yarl import URL
 
 from .exceptions import (
     ForecastSolarAuthenticationError,
+    ForecastSolarConfigError,
     ForecastSolarConnectionError,
     ForecastSolarError,
-    ForecastSolarRequestError,
     ForecastSolarRatelimit,
+    ForecastSolarRequestError,
 )
 from .models import Estimate, Ratelimit
 
@@ -119,6 +120,10 @@ class ForecastSolar:
         if response.status in (401, 403):
             data = await response.json()
             raise ForecastSolarAuthenticationError(data["message"])
+
+        if response.status == 422:
+            data = await response.text()
+            raise ForecastSolarConfigError(data)
 
         if response.status == 429:
             data = await response.json()

--- a/forecast_solar/exceptions.py
+++ b/forecast_solar/exceptions.py
@@ -10,6 +10,14 @@ class ForecastSolarConnectionError(ForecastSolarError):
     """Forecast.Solar API connection exception."""
 
 
+class ForecastSolarConfigError(ForecastSolarError):
+    """Forecast.Solar API configuration exception."""
+
+    def __init__(self, data: str) -> None:
+        """Init a solar config error."""
+        super().__init__(f"{data} (error 422)")
+
+
 class ForecastSolarAuthenticationError(ForecastSolarError):
     """Forecast.Solar API authentication exception."""
 


### PR DESCRIPTION
This allows us to catch the [422 status code](https://doc.forecast.solar/doku.php?id=api#response
) and show a clear error message to the user from the API.

For example:
```py
Traceback (most recent call last):
  File "/home/klaas/python-packages/forecast_solar/example.py", line 71, in <module>
    asyncio.run(main())
  File "/home/klaas/.pyenv/versions/3.10.6/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/home/klaas/.pyenv/versions/3.10.6/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/home/klaas/python-packages/forecast_solar/example.py", line 21, in main
    estimate = await forecast.estimate()
  File "/home/klaas/python-packages/forecast_solar/forecast_solar/__init__.py", line 161, in estimate
    data = await self._request(
  File "/home/klaas/python-packages/forecast_solar/forecast_solar/__init__.py", line 126, in _request
    raise ForecastSolarConfigError(data)
forecast_solar.exceptions.ForecastSolarConfigError: Invalid location, invalid plane definition or kWp == 0 (error 422)
```