### PR TITLE
add validation methods

### DIFF
--- a/forecast_solar/__init__.py
+++ b/forecast_solar/__init__.py
@@ -44,9 +44,9 @@ class ForecastSolar:
     async def _request(
         self,
         uri: str,
+        *,
         rate_limit=True,
         authenticate=True,
-        *,
         params: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
         """Handle a request to the Forecast.Solar API.
@@ -160,8 +160,8 @@ class ForecastSolar:
         await self._request(
             f"check/{self.latitude}/{self.longitude}"
             f"/{self.declination}/{self.azimuth}/{self.kwp}",
-            False,
-            False,
+            rate_limit=False,
+            authenticate=False,
         )
 
         return True
@@ -173,7 +173,7 @@ class ForecastSolar:
             True, if api key is valid
         """
 
-        await self._request("info", False)
+        await self._request("info", rate_limit=False)
 
         return True
 

--- a/forecast_solar/__init__.py
+++ b/forecast_solar/__init__.py
@@ -150,7 +150,7 @@ class ForecastSolar:
 
         return await response.json()
 
-    async def validate_plane(self):
+    async def validate_plane(self) -> bool:
         """Validate plane by calling the Forecast.Solar API
 
         Returns:
@@ -166,7 +166,7 @@ class ForecastSolar:
 
         return True
 
-    async def validate_api_key(self):
+    async def validate_api_key(self) -> bool:
         """Validate api key by calling the Forecast.Solar API
 
         Returns:

--- a/forecast_solar/exceptions.py
+++ b/forecast_solar/exceptions.py
@@ -26,8 +26,10 @@ class ForecastSolarAuthenticationError(ForecastSolarError):
 
         https://doc.forecast.solar/doku.php?id=api#invalid_request
         """
-        super().__init__(f'{data["text"]} (error {data["code"]})')
-        self.code = data["code"]
+        # seems that code is missing in response in some endpoints (i.e /info)
+        code = data.get("code")
+        super().__init__(f'{data["text"]} (error {code})')
+        self.code = code
 
 
 class ForecastSolarRequestError(ForecastSolarError):


### PR DESCRIPTION
Add methods for validation to support future implementation validation of parameters and api key in Home Assistant `config flow` in order to avoid creating broken sensors. To partially support https://github.com/home-assistant/core/issues/106771

* validate api key (validation success not tested since I do not have an api key atm)
  -> (https://doc.forecast.solar/for_developers)
* validate plane -> (https://doc.forecast.solar/api:misc)

I had to add `rate_limit` and `authenticate` flags to `_request` method since `/check` endpoint does not provide rate limit headers in response and does not seem to exist behind authentication (at least not according to the docs)