### PR TITLE
Raise ForecastSolarConnectionError when service is down for maintenance

### DIFF
--- a/forecast_solar/__init__.py
+++ b/forecast_solar/__init__.py
@@ -108,7 +108,7 @@ class ForecastSolar:
             ssl=False,
         )
 
-        if response.status == 502:
+        if response.status in (502, 503):
             raise ForecastSolarConnectionError(
                 "The Forecast.Solar API is unreachable, "
             )


### PR DESCRIPTION

Raise ForecastSolarConnectionError when service is down for maintenance

According to docs:

![image](https://github.com/home-assistant-libs/forecast_solar/assets/10961167/bea9a8bc-a58b-48ed-99fd-bd551dcd6ed2)
