### PR TITLE
Ensure black formatting stability in workflow

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.0.2
-      - uses: psf/black@stable
+      - uses: psf/black@22.8.0
         with:
           version: "~= 22.0"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,4 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.0.2
-      - uses: psf/black@22.8.0
+      - uses: psf/black@stable
+        with:
+          version: "~= 22.0"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.0.2
-      - uses: psf/black@22.8.0
+      - uses: psf/black@24.3.0
         with:
           version: "~= 22.0"


### PR DESCRIPTION
~~I noticed my PRs are failing black even though i've made no changes. I think using recommended `psf/black@stable` action version and stability `version` will fix this~~

I noticed my PRs are failing black even though i've made no changes. Using `psf/black@24.3.0` action version and stability `version: "~= 22.0"` will fix this


Seems that using `psf/black@xx.yy.zz` action does not guarantee `black==xx.yy.zz` format rules are used as one would expect.

- [x] use `psf/black@23.3.0` and add stability `version: "~= 22.0"` to prevent workflow from failing due to upstream changes in black format
