### PR TITLE
Rename the ratelimit exception

### DIFF
--- a/examples/estimate.py
+++ b/examples/estimate.py
@@ -3,7 +3,7 @@ import dataclasses
 from datetime import datetime, timezone, timedelta
 from pprint import pprint
 
-from forecast_solar import ForecastSolar, ForecastSolarRatelimit
+from forecast_solar import ForecastSolar, ForecastSolarRatelimitError
 
 
 async def main():
@@ -19,7 +19,7 @@ async def main():
     ) as forecast:
         try:
             estimate = await forecast.estimate()
-        except ForecastSolarRatelimit as err:
+        except ForecastSolarRatelimitError as err:
             print("Ratelimit reached")
             print(f"Rate limit resets at {err.reset_at}")
             reset_period = err.reset_at - datetime.now(timezone.utc)

--- a/src/forecast_solar/__init__.py
+++ b/src/forecast_solar/__init__.py
@@ -6,7 +6,7 @@ from .exceptions import (
     ForecastSolarConfigError,
     ForecastSolarAuthenticationError,
     ForecastSolarRequestError,
-    ForecastSolarRatelimit,
+    ForecastSolarRatelimitError,
 )
 from .models import Estimate, AccountType, Ratelimit
 from .forecast_solar import ForecastSolar
@@ -19,7 +19,7 @@ __all__ = [
     "ForecastSolarConfigError",
     "ForecastSolarConnectionError",
     "ForecastSolarError",
-    "ForecastSolarRatelimit",
+    "ForecastSolarRatelimitError",
     "ForecastSolarRequestError",
     "Ratelimit",
 ]

--- a/src/forecast_solar/exceptions.py
+++ b/src/forecast_solar/exceptions.py
@@ -45,7 +45,7 @@ class ForecastSolarRequestError(ForecastSolarError):
         self.code = data["code"]
 
 
-class ForecastSolarRatelimit(ForecastSolarRequestError):
+class ForecastSolarRatelimitError(ForecastSolarRequestError):
     """Forecast.Solar maximum number of requests reached exception."""
 
     def __init__(self, data: dict) -> None:

--- a/src/forecast_solar/forecast_solar.py
+++ b/src/forecast_solar/forecast_solar.py
@@ -15,7 +15,7 @@ from .exceptions import (
     ForecastSolarConfigError,
     ForecastSolarConnectionError,
     ForecastSolarError,
-    ForecastSolarRatelimit,
+    ForecastSolarRatelimitError,
     ForecastSolarRequestError,
 )
 from .models import Estimate, Ratelimit
@@ -74,7 +74,7 @@ class ForecastSolar:
                 Forecast.Solar API.
             ForecastSolarRequestError: There is something wrong with the
                 variables used in the request.
-            ForecastSolarRatelimit: The number of requests has exceeded
+            ForecastSolarRatelimitError: The number of requests has exceeded
                 the rate limit of the Forecast.Solar API.
         """
 
@@ -132,7 +132,7 @@ class ForecastSolar:
 
         if response.status == 429:
             data = await response.json()
-            raise ForecastSolarRatelimit(data["message"])
+            raise ForecastSolarRatelimitError(data["message"])
 
         if rate_limit and response.status < 500:
             self.ratelimit = Ratelimit.from_response(response)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,7 +5,7 @@ from aresponses import ResponsesMockServer
 
 from forecast_solar import (
     ForecastSolar,
-    ForecastSolarRatelimit,
+    ForecastSolarRatelimitError,
     ForecastSolarConfigError,
     ForecastSolarAuthenticationError,
     ForecastSolarRequestError,
@@ -103,7 +103,7 @@ async def test_status_429(
             text=load_fixtures("ratelimit.json"),
         ),
     )
-    with pytest.raises(ForecastSolarRatelimit):
+    with pytest.raises(ForecastSolarRatelimitError):
         assert await forecast_client._request("test")
 
 


### PR DESCRIPTION
Ruff sets the rule that exception should have `Error` in the name, this PR will change this everywhere.

## Breaking change

Created a seperate PR so I can mark it as breaking change because it could break code from others that would catch the old exception name in a try-catch block.