### PR TITLE
Update time parameter format from iso8601 to utc

### DIFF
--- a/src/forecast_solar/forecast_solar.py
+++ b/src/forecast_solar/forecast_solar.py
@@ -194,7 +194,7 @@ class ForecastSolar:
             A Estimate object, with a estimated production forecast.
 
         """
-        params = {"time": "iso8601", "damping": str(self.damping)}
+        params = {"time": "utc", "damping": str(self.damping)}
         if self.inverter is not None:
             params["inverter"] = str(self.inverter)
         if self.horizon is not None:


### PR DESCRIPTION
The proposal to no longer use local time but UTC time, in the hope that this will prevent people from having a time-shifted graph in, for example, the energy dashboard in Home Assistant.