### PR TITLE
Fix rate limit check to only update ratelimit on successful response

### DIFF
--- a/src/forecast_solar/forecast_solar.py
+++ b/src/forecast_solar/forecast_solar.py
@@ -137,7 +137,7 @@ class ForecastSolar:
             data = await response.json()
             raise ForecastSolarRatelimitError(data["message"])
 
-        if rate_limit and response.status < 500:
+        if rate_limit and response.status == 200:
             self.ratelimit = Ratelimit.from_response(response)
 
         response.raise_for_status()


### PR DESCRIPTION
Only return the Ratelimit info if there was a successful request.

This should prevent users from getting a KeyError exception on `X-Ratelimit-Limit` because the API is down again, for example.