### PR TITLE
Configurable time format in ForecastSolar class

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 -->
 
 ## Python API fetching Solarpanels forecast information.
+
 <!-- PROJECT SHIELDS -->
+
 ![Project Maintenance][maintenance-shield]
 [![License][license-shield]](LICENSE)
 
@@ -127,26 +129,27 @@ if __name__ == "__main__":
 
 ## ForecastSolar object
 
-| Parameter | value type | Description                                                                                                 |
-| --------- | ---------- |-------------------------------------------------------------------------------------------------------------|
-| `api_key` | `str` | Your API key from [forecast.solar](https://forecast.solar) (optional)                                       |
-| `declination` | `int` | The tilt of the solar panels (required)                                                                     |
-| `azimuth` | `int` | The direction the solar panels are facing (required)                                                        |
-| `kwp` | `float` | The size of the solar panels in kWp (required)                                                              |
-| `damping` | `float` | The damping of the solar panels, [read this][forecast-damping] for more information (optional)              |
-| `damping_morning` | `float` | The damping of the solar panels in the morning (optional)                                                   |
-| `damping_evening` | `float` | The damping of the solar panels in the evening (optional)                                                   |
-| `inverter` | `float` | The maximum power of your inverter in kilo watts (optional)                                                 |
-| `horizon` | `str` | A list of **comma separated** degrees values, [read this][forecast-horizon] for more information (optional) |
-| `planes` | `list[Plane]` | A list of additional Plane objects for multi-plane setups. Only used when an API key is provided (optional)                                                  |
+| Parameter         | value type    | Description                                                                                                 |
+| ----------------- | ------------- | ----------------------------------------------------------------------------------------------------------- |
+| `api_key`         | `str`         | Your API key from [forecast.solar](https://forecast.solar) (optional)                                       |
+| `declination`     | `int`         | The tilt of the solar panels (required)                                                                     |
+| `azimuth`         | `int`         | The direction the solar panels are facing (required)                                                        |
+| `kwp`             | `float`       | The size of the solar panels in kWp (required)                                                              |
+| `damping`         | `float`       | The damping of the solar panels, [read this][forecast-damping] for more information (optional)              |
+| `damping_morning` | `float`       | The damping of the solar panels in the morning (optional)                                                   |
+| `damping_evening` | `float`       | The damping of the solar panels in the evening (optional)                                                   |
+| `inverter`        | `float`       | The maximum power of your inverter in kilo watts (optional)                                                 |
+| `horizon`         | `str`         | A list of **comma separated** degrees values, [read this][forecast-horizon] for more information (optional) |
+| `planes`          | `list[Plane]` | A list of additional Plane objects for multi-plane setups. Only used when an API key is provided (optional) |
+| `time`            | `str`         | A time format specifier, [read this][forecast-time] for more information (optional)                         |
 
 ## Plane object
 
-| Parameter | value type | Description |
-| --------- | ---------- | ----------- |
-| `declination` | `float` | The tilt of the solar panels (required) |
-| `azimuth` | `float` | The direction the solar panels are facing (required) |
-| `kwp` | `float` | The size of the solar panels in kWp (required) |
+| Parameter     | value type | Description                                          |
+| ------------- | ---------- | ---------------------------------------------------- |
+| `declination` | `float`    | The tilt of the solar panels (required)              |
+| `azimuth`     | `float`    | The direction the solar panels are facing (required) |
+| `kwp`         | `float`    | The size of the solar panels in kWp (required)       |
 
 ## estimate() method
 
@@ -235,11 +238,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 <!-- LINKS -->
+
 [forecast-horizon]: https://doc.forecast.solar/doku.php?id=api#horizon
 [forecast-damping]: https://doc.forecast.solar/doku.php?id=damping
 [forecast-subscription]: https://doc.forecast.solar/account_models
+[forecast-time]: https://doc.forecast.solar/doku.php?id=api#time
 
 <!-- MARKDOWN LINKS & IMAGES -->
+
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg?style=for-the-badge
 [contributors-shield]: https://img.shields.io/github/contributors/home-assistant-libs/forecast_solar.svg?style=for-the-badge
 [contributors-url]: https://github.com/home-assistant-libs/forecast_solar/graphs/contributors
@@ -253,7 +259,6 @@ SOFTWARE.
 [commits-shield]: https://img.shields.io/github/commit-activity/y/home-assistant-libs/forecast_solar.svg?style=for-the-badge
 [commits]: https://github.com/home-assistant-libs/forecast_solar/commits/master
 [last-commit-shield]: https://img.shields.io/github/last-commit/home-assistant-libs/forecast_solar.svg?style=for-the-badge
-
 [poetry-install]: https://python-poetry.org/docs/#installation
 [poetry]: https://python-poetry.org
 [prek]: https://github.com/j178/prek

--- a/src/forecast_solar/forecast_solar.py
+++ b/src/forecast_solar/forecast_solar.py
@@ -35,6 +35,7 @@ class ForecastSolar:
     damping_evening: float | None = None
     horizon: str | None = None
     planes: list[Plane] | None = None
+    time: str = "utc"
 
     session: ClientSession | None = None
     ratelimit: Ratelimit | None = None
@@ -195,7 +196,9 @@ class ForecastSolar:
             A Estimate object, with a estimated production forecast.
 
         """
-        params = {"time": "utc", "damping": str(self.damping)}
+        params = {"damping": str(self.damping)}
+        if self.time is not None:
+            params["time"] = str(self.time)
         if self.inverter is not None:
             params["inverter"] = str(self.inverter)
         if self.horizon is not None:


### PR DESCRIPTION
Permits setting the time format per https://doc.forecast.solar/doku.php?id=api#time

Related to #294 

Default time format of `utc` is maintained. This merely permits the user to specify the time format to use rather than hard coding `utc`. 