### PR TITLE
fix: handle missing peak production data gracefully

### DIFF
--- a/src/forecast_solar/models.py
+++ b/src/forecast_solar/models.py
@@ -127,18 +127,12 @@ class Estimate:
     @property
     def power_highest_peak_time_today(self) -> datetime | None:
         """Return datetime with highest power production moment today."""
-        try:
-            return self.peak_production_time(self.now().date())
-        except RuntimeError:
-            return None
+        return self.peak_production_time(self.now().date())
 
     @property
     def power_highest_peak_time_tomorrow(self) -> datetime | None:
         """Return datetime with highest power production moment tomorrow."""
-        try:
-            return self.peak_production_time(self.now().date() + timedelta(days=1))
-        except RuntimeError:
-            return None
+        return self.peak_production_time(self.now().date() + timedelta(days=1))
 
     @property
     def energy_current_hour(self) -> int:
@@ -161,18 +155,18 @@ class Estimate:
         """Return the current timestamp in the API timezone."""
         return datetime.now(tz=ZoneInfo(self.api_timezone))
 
-    def peak_production_time(self, specific_date: date) -> datetime:
+    def peak_production_time(self, specific_date: date) -> datetime | None:
         """Return the peak time on a specific date."""
-        value = max(
-            (watt for date, watt in self.watts.items() if date.date() == specific_date),
+        peak = max(
+            (
+                (timestamp, watt)
+                for timestamp, watt in self.watts.items()
+                if timestamp.date() == specific_date
+            ),
+            key=lambda item: item[1],
             default=None,
         )
-        if value is None:
-            raise RuntimeError("No peak production time found")
-        for timestamp, watt in self.watts.items():
-            if watt == value:
-                return timestamp
-        raise RuntimeError("No peak production time found")
+        return peak[0] if peak is not None else None
 
     def power_production_at_time(self, time: datetime) -> int:
         """Return estimated power production at a specific time."""

--- a/src/forecast_solar/models.py
+++ b/src/forecast_solar/models.py
@@ -125,14 +125,20 @@ class Estimate:
         return self.power_production_at_time(self.now())
 
     @property
-    def power_highest_peak_time_today(self) -> datetime:
+    def power_highest_peak_time_today(self) -> datetime | None:
         """Return datetime with highest power production moment today."""
-        return self.peak_production_time(self.now().date())
+        try:
+            return self.peak_production_time(self.now().date())
+        except RuntimeError:
+            return None
 
     @property
-    def power_highest_peak_time_tomorrow(self) -> datetime:
+    def power_highest_peak_time_tomorrow(self) -> datetime | None:
         """Return datetime with highest power production moment tomorrow."""
-        return self.peak_production_time(self.now().date() + timedelta(days=1))
+        try:
+            return self.peak_production_time(self.now().date() + timedelta(days=1))
+        except RuntimeError:
+            return None
 
     @property
     def energy_current_hour(self) -> int:
@@ -161,6 +167,8 @@ class Estimate:
             (watt for date, watt in self.watts.items() if date.date() == specific_date),
             default=None,
         )
+        if value is None:
+            raise RuntimeError("No peak production time found")
         for timestamp, watt in self.watts.items():
             if watt == value:
                 return timestamp

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 """Test the models."""
 
-from datetime import datetime
+from datetime import date, datetime
 
 import pytest
 from aresponses import ResponsesMockServer

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -263,3 +263,37 @@ async def test_planes_ignored_without_api_key(
     ) as forecast:
         estimate = await forecast.estimate()
         assert estimate is not None
+
+
+def test_peak_production_time_with_empty_data() -> None:
+    """Test that peak production time properties return None when no data is available."""
+    # Create an Estimate with empty data to simulate when no production data is available
+    estimate = Estimate(
+        watts={},  # Empty watts data
+        wh_period={},
+        wh_days={},
+        api_rate_limit=60,
+        api_timezone="Europe/Amsterdam",
+    )
+
+    # Test that properties return None instead of raising RuntimeError
+    assert estimate.power_highest_peak_time_today is None
+    assert estimate.power_highest_peak_time_tomorrow is None
+
+
+def test_peak_production_time_method_with_empty_data() -> None:
+    """Test that peak_production_time method raises RuntimeError when no data is available."""
+    from datetime import date
+
+    # Create an Estimate with empty data
+    estimate = Estimate(
+        watts={},  # Empty watts data
+        wh_period={},
+        wh_days={},
+        api_rate_limit=60,
+        api_timezone="Europe/Amsterdam",
+    )
+
+    # Test that the underlying method still raises RuntimeError
+    with pytest.raises(RuntimeError, match="No peak production time found"):
+        estimate.peak_production_time(date(2024, 4, 26))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -265,35 +265,39 @@ async def test_planes_ignored_without_api_key(
         assert estimate is not None
 
 
-def test_peak_production_time_with_empty_data() -> None:
-    """Test that peak production time properties return None when no data is available."""
-    # Create an Estimate with empty data to simulate when no production data is available
-    estimate = Estimate(
-        watts={},  # Empty watts data
+@pytest.mark.freeze_time("2024-04-26T12:00:00+02:00")
+def test_peak_time_properties_return_none_without_date_data() -> None:
+    """Test peak time properties return None when no peak is available."""
+    forecast = Estimate(
+        watts={
+            datetime.fromisoformat("2024-04-27T12:00:00+02:00"): 42,
+        },
         wh_period={},
         wh_days={},
-        api_rate_limit=60,
+        api_rate_limit=10,
         api_timezone="Europe/Amsterdam",
     )
 
-    # Test that properties return None instead of raising RuntimeError
-    assert estimate.power_highest_peak_time_today is None
-    assert estimate.power_highest_peak_time_tomorrow is None
+    assert forecast.power_highest_peak_time_today is None
+    assert forecast.power_highest_peak_time_tomorrow == datetime.fromisoformat(
+        "2024-04-27T12:00:00+02:00"
+    )
+    assert forecast.peak_production_time(date(2024, 4, 26)) is None
 
 
-def test_peak_production_time_method_with_empty_data() -> None:
-    """Test that peak_production_time method raises RuntimeError when no data is available."""
-    from datetime import date
-
-    # Create an Estimate with empty data
-    estimate = Estimate(
-        watts={},  # Empty watts data
+def test_peak_production_time_filters_peak_by_date() -> None:
+    """Test peak time only returns a timestamp for the requested date."""
+    forecast = Estimate(
+        watts={
+            datetime.fromisoformat("2024-04-25T23:00:00+02:00"): 0,
+            datetime.fromisoformat("2024-04-26T00:00:00+02:00"): 0,
+        },
         wh_period={},
         wh_days={},
-        api_rate_limit=60,
+        api_rate_limit=10,
         api_timezone="Europe/Amsterdam",
     )
 
-    # Test that the underlying method still raises RuntimeError
-    with pytest.raises(RuntimeError, match="No peak production time found"):
-        estimate.peak_production_time(date(2024, 4, 26))
+    assert forecast.peak_production_time(date(2024, 4, 26)) == datetime.fromisoformat(
+        "2024-04-26T00:00:00+02:00"
+    )


### PR DESCRIPTION
- add `None` check in `peak_production_time` method to catch empty data
- update `power_highest_peak_time` properties to return `None` instead of raising `RuntimeError`
- prevents crashes when no solar production data is available for a given date

related stacktrace:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/site-packages/homeassistant/helpers/update_coordinator.py", line 203, in async_update_listeners
    update_callback()
    ~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.14/site-packages/homeassistant/helpers/update_coordinator.py", line 662, in _handle_coordinator_update
    self.async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.14/site-packages/homeassistant/helpers/entity.py", line 1054, in async_write_ha_state
    self._async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.14/site-packages/homeassistant/helpers/entity.py", line 1203, in _async_write_ha_state
    ) = self.__async_calculate_state()
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.14/site-packages/homeassistant/helpers/entity.py", line 1110, in __async_calculate_state
    state = self._stringify_state(available)
  File "/usr/local/lib/python3.14/site-packages/homeassistant/helpers/entity.py", line 1060, in _stringify_state
    if (state := self.state) is None:
                 ^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/homeassistant/components/sensor/__init__.py", line 588, in state
    value = self.native_value
            ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/homeassistant/components/forecast_solar/sensor.py", line 189, in native_value
    state: StateType | datetime = getattr(
                                  ~~~~~~~^
        self.coordinator.data, self.entity_description.key
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/forecast_solar/models.py", line 130, in power_highest_peak_time_today
    return self.peak_production_time(self.now().date())
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/forecast_solar/models.py", line 167, in peak_production_time
    raise RuntimeError("No peak production time found")
RuntimeError: No peak production time found
```

Related to: #331 