### PR TITLE
Update PR label workflow and pre-commit stages

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -3,7 +3,7 @@ name: PR Labels
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - labeled
@@ -11,17 +11,20 @@ on:
       - synchronize
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   pr_labels:
     name: Verify
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: 🏷 Verify PR has a valid label
-        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        uses: klaasnicolaas/action-pr-labels@4b8aaf02640f39706f5a096ea72572bec217c17a # v3.1.0
         with:
-          pull-request-number: "${{ github.event.pull_request.number }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: >-
             breaking-change, bugfix, documentation, enhancement,
             refactor, performance, new-feature, maintenance, ci, dependencies
-          disable-reviews: true

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: read
     steps:
       - name: 🏷 Verify PR has a valid label
-        uses: klaasnicolaas/action-pr-labels@4b8aaf02640f39706f5a096ea72572bec217c17a # v3.1.0
+        uses: klaasnicolaas/action-pr-labels@v3.1.1
         with:
           valid-labels: >-
             breaking-change, bugfix, documentation, enhancement,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,14 +8,14 @@ repos:
         types: [python]
         entry: poetry run ruff check --fix
         require_serial: true
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: ruff-format
         name: 🐶 Ruff Formatter
         language: system
         types: [python]
         entry: poetry run ruff format
         require_serial: true
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: check-ast
         name: 🐍 Check Python AST
         language: system
@@ -35,7 +35,7 @@ repos:
         language: system
         types: [text, executable]
         entry: poetry run check-executables-have-shebangs
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: check-json
         name: ｛ Check JSON files
         language: system
@@ -76,7 +76,7 @@ repos:
         language: system
         types: [text]
         entry: poetry run end-of-file-fixer
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: ty
         name: 🆎 Static type checking using ty
         language: system
@@ -107,7 +107,7 @@ repos:
         language: system
         types: [text]
         entry: poetry run trailing-whitespace-fixer
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: yamllint
         name: 🎗 Check YAML files with yamllint
         language: system


### PR DESCRIPTION
Update the PR label workflow to run on `pull_request` with explicit read-only permissions and switch validation to `klaasnicolaas/action-pr-labels`.

Also update the pre-commit hook stage names from the deprecated `commit` and `push` values to `pre-commit` and `pre-push`.