### PR TITLE
Fix energy_current_hour always returning 0 on public accounts

### DIFF
--- a/src/forecast_solar/models.py
+++ b/src/forecast_solar/models.py
@@ -137,9 +137,19 @@ class Estimate:
     @property
     def energy_current_hour(self) -> int:
         """Return the estimated energy production for the current hour."""
+        # `wh_period` entries are keyed by the *end* of the period they
+        # cover (e.g. the entry timestamped 11:00 holds the production
+        # for 10:00-11:00), so the window has to be shifted a microsecond
+        # forward on both ends: otherwise the entry for the hour that
+        # just ended (timestamped exactly at hour_start) is picked up
+        # instead, and the entry that actually covers the current hour
+        # (timestamped exactly at hour_start + 1h) is excluded by the
+        # upper bound. On public/free accounts, where `wh_period` only
+        # has one entry per hour, that made this always return 0.
+        hour_start = self.now().replace(minute=0, second=0, microsecond=0)
         return _interval_value_sum(
-            self.now().replace(minute=0, second=0, microsecond=0),
-            self.now().replace(minute=0, second=0, microsecond=0) + timedelta(hours=1),
+            hour_start + timedelta(microseconds=1),
+            hour_start + timedelta(hours=1, microseconds=1),
             self.wh_period,
         )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -42,7 +42,10 @@ async def test_estimated_forecast(
 
     assert forecast.power_production_now == 773
     assert forecast.energy_production_today_remaining == 4144
-    assert forecast.energy_current_hour == 821
+    # wh_period is keyed by the end of each period, so at exactly 12:00
+    # "this hour" (12:00-13:00) is the entry timestamped 13:00, not 12:00
+    # (which is the hour that just ended).
+    assert forecast.energy_current_hour == 742
 
     assert forecast.power_highest_peak_time_today == datetime.fromisoformat(
         "2024-04-26T11:00:00+02:00"
@@ -88,7 +91,10 @@ async def test_estimated_forecast_with_subscription(
 
     assert forecast.power_production_now == 92
     assert forecast.energy_production_today_remaining == 5783
-    assert forecast.energy_current_hour == 96
+    # 30-minute resolution: "this hour" (07:00-08:00) is the sum of the
+    # periods ending at 07:30 and 08:00, not the periods ending at 07:00
+    # and 07:30.
+    assert forecast.energy_current_hour == 153
 
     assert forecast.power_highest_peak_time_today == datetime.fromisoformat(
         "2024-04-27T13:30:00+02:00"
@@ -301,3 +307,37 @@ def test_peak_production_time_filters_peak_by_date() -> None:
     assert forecast.peak_production_time(date(2024, 4, 26)) == datetime.fromisoformat(
         "2024-04-26T00:00:00+02:00"
     )
+
+
+@pytest.mark.freeze_time("2024-04-26T10:29:00+02:00")
+def test_energy_current_hour_public_account_mid_hour() -> None:
+    """Regression test: energy_current_hour must not be 0 mid-hour on a public account.
+
+    On a public/free account, `wh_period` only has one entry per hour,
+    keyed by the *end* of the period it covers. Before this fix,
+    `energy_current_hour` looked for entries in `[hour_start, hour_start
+    + 1h)`, which only ever matched the entry for the *previous* hour
+    (timestamped exactly at hour_start) and always excluded the entry
+    that actually covers the current hour (timestamped exactly at
+    hour_start + 1h). Unless `now` happened to land exactly on the hour,
+    that meant `energy_current_hour` was always 0 for public accounts.
+    """
+    forecast = Estimate(
+        watts={
+            datetime.fromisoformat("2024-04-26T10:00:00+02:00"): 3000,
+            datetime.fromisoformat("2024-04-26T11:00:00+02:00"): 4500,
+        },
+        wh_period={
+            # Production for 09:00-10:00.
+            datetime.fromisoformat("2024-04-26T10:00:00+02:00"): 1800,
+            # Production for 10:00-11:00 - this is "the current hour".
+            datetime.fromisoformat("2024-04-26T11:00:00+02:00"): 3750,
+            # Production for 11:00-12:00.
+            datetime.fromisoformat("2024-04-26T12:00:00+02:00"): 4900,
+        },
+        wh_days={},
+        api_rate_limit=12,
+        api_timezone="Europe/Amsterdam",
+    )
+
+    assert forecast.energy_current_hour == 3750


### PR DESCRIPTION
## Bug

`Estimate.energy_current_hour` sums `wh_period` over `[hour_start, hour_start + 1h)`. `wh_period` entries are keyed by the **end** of the period they cover (e.g. the entry timestamped `11:00` holds the production for `10:00-11:00`), so that window is misaligned by one bucket:

- The entry timestamped exactly at `hour_start` (the hour that *just ended*) is included.
- The entry timestamped exactly at `hour_start + 1h` (the one that actually covers *this* hour) is excluded by the `timestamp >= interval_end: break` upper bound.

On a **public/free account**, where `wh_period` only has one entry per hour, that means the entry which covers the current hour is never in the summed range — `energy_current_hour` is `0` at every `now()` except the rare instant it lands exactly on the hour. I hit this on a live public-account install: at `10:29` local time, with `power_production_now` correctly reporting `5480` W, `energy_current_hour` reported `0`. Home Assistant's Energy dashboard uses this sensor to draw the solar forecast overlay, so the practical symptom is a visible gap between the actual-production bars and the forecast line for the remainder of the current hour.

Live diagnostics payload that reproduces it (fed straight into `Estimate` with `now()` patched to `2026-08-30T10:29:00+10:00`):

```
watts:     {"...T00:00+00:00": 5480, "...T01:00+00:00": 5973, ...}
wh_period: {"...T00:00+00:00": 0,    "...T01:00+00:00": 5727, ...}

power_production_now  -> 5480   (correct)
energy_current_hour    -> 0      (wrong: should be 5727, the entry for 00:00-01:00 UTC)
sum_energy_production(1) -> 5727 (this one is fine - see below)
```

This looks like a boundary regression from #31 / #37: that fix correctly moved `energy_current_hour` from a single-point lookup (`_timed_value`) to an interval sum, but the new interval's bounds assume `wh_period` is keyed by period *start*, when it's actually keyed by period *end* - the same assumption `sum_energy_production` already works around via its `minute=59, second=59, microsecond=999` trick.

## Fix

Shift both bounds of the `energy_current_hour` window forward by a microsecond, mirroring the trick already used in `sum_energy_production`, so the window becomes `(hour_start, hour_start + 1h]` and lines up with `wh_period`'s end-of-period keys regardless of data resolution or what minute `now()` is at.

## Tests

The two existing fixtures both freeze `now()` exactly on the hour, which happens to dodge the bug by accident - the window `[hour_start, hour_start+1h)` still contains *an* entry (the previous hour's, timestamped at `hour_start`), so the old code returned a plausible-looking but wrong number (the hour that just ended) instead of `0`. Both assertions changed accordingly (`821 -> 742`, `96 -> 153`), and I added a regression test (`test_energy_current_hour_public_account_mid_hour`) that freezes `now()` mid-hour on a public-style (hourly-resolution) account, which is what actually surfaces the bug.

`pytest` (20 passed, 100% coverage), `ruff check`, and `ruff format --check` all pass locally.